### PR TITLE
v1.2.10 #BACKEND-335

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vingle-corgi",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Restful HTTP Framework for AWS Lambda - AWS API Gateway Proxy Integration",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",

--- a/src/__test__/root-namespace_spec.ts
+++ b/src/__test__/root-namespace_spec.ts
@@ -29,19 +29,14 @@ describe("RootNamespace", () => {
         }
       } as any);
       console.log(JSON.stringify(res, null, 2));
-      expect(res).to.deep.eq({
-        "statusCode": 500,
-        "headers": {
-          "Content-Type": "application/json; charset=utf-8"
-        },
-        "body": JSON.stringify(
-          {
-            errors: [
-              { id: 'request-id', message: 'TEST ERROR' }
-            ]
-          }
-        )
+      expect(JSON.parse(res["body"])).to.deep.eq({
+        'error':{
+          'id':'request-id',
+          'summary':'Ooops something went wrong',
+          'message':'TEST ERROR'
+        }
       });
+      expect(res.statusCode).to.be.eq(500);
     });
   });
 });

--- a/src/root-namespace.ts
+++ b/src/root-namespace.ts
@@ -4,11 +4,15 @@ import { Namespace, Routes } from './namespace';
 
 //  http://jsonapi.org/format/#error-objects
 export interface StandardErrorResponseBody {
-  errors: Array<{
+  error: {
     id: string;
     message: string;
-    code?: number;
-  }>;
+    summary?: string;
+    errors?: Array<{
+      source: string;
+      reason: string;
+    }>
+  }
 }
 
 export class RootNamespace extends Namespace {
@@ -16,10 +20,11 @@ export class RootNamespace extends Namespace {
     super('', {
       exceptionHandler: async function(error: Error) {
         const body: StandardErrorResponseBody = {
-          errors: [{
+          error: {
             id: this.requestId,
+            summary: 'Ooops something went wrong',
             message: error.message,
-          }]
+          }
         };
 
         console.log(`Error - ${this.requestId}\n${error.stack}`);


### PR DESCRIPTION
**New Behavior**
Now RootNamespace default error handler returns same form of error response body as Vingle API server 
