### PR TITLE
v1.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vingle-corgi",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Restful HTTP Framework for AWS Lambda - AWS API Gateway Proxy Integration",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",

--- a/src/__test__/route_spec.ts
+++ b/src/__test__/route_spec.ts
@@ -14,6 +14,7 @@ describe("Route", () => {
         new Route({
           path: '/followers',
           method: 'GET',
+          operationId: 'getFollowers',
           desc: 'List of users that following me',
           handler: async function(this: RoutingContext) {
             return this.json({
@@ -22,6 +23,7 @@ describe("Route", () => {
           }
         });
 
+      expect(route.operationId).to.eq("getFollowers");
       expect(route.path).to.deep.eq('/followers');
       expect(route.method).to.deep.eq('GET');
       expect(route.desc).to.deep.eq('List of users that following me');

--- a/src/__test__/swagger_spec.ts
+++ b/src/__test__/swagger_spec.ts
@@ -29,7 +29,7 @@ describe("SwaggerRoute", () => {
     }, async function(this: RoutingContext) {
       return this.json({});
     }),
-    Route.POST('/api/a', 'a', {}, async function(this: RoutingContext) {
+    Route.POST('/api/a', { desc: 'a', operationId: "GetAPIa" }, {}, async function(this: RoutingContext) {
       return this.json({});
     }),
     Route.GET('/api/c', 'a', {}, async function(this: RoutingContext) {
@@ -116,7 +116,7 @@ describe("SwaggerRoute", () => {
                 "description": "Success"
               }
             },
-            "operationId": "PostApiA"
+            "operationId": "GetAPIa",
           }
         },
         "/api/c": {

--- a/src/route.ts
+++ b/src/route.ts
@@ -14,30 +14,39 @@ export class Route {
   get desc() { return this.options.desc; }
   get handler() { return this.options.handler; }
   get params() { return this.options.params; }
+  get operationId() { return this.options.operationId; }
 
   // Simplified Constructors
-  static GET(path: string, desc: string, params: ParameterDefinitionMap, handler: RouteHandler) {
-    return this._factory(path, 'GET', desc, params, handler);
+  static GET(path: string, descOrOptions: string | RouteSimplifiedOptions, params: ParameterDefinitionMap, handler: RouteHandler) {
+    return this._factory(path, 'GET', descOrOptions, params, handler);
   }
-  static PUT(path: string, desc: string, params: ParameterDefinitionMap, handler: RouteHandler) {
-    return this._factory(path, 'PUT', desc, params, handler);
+  static PUT(path: string, descOrOptions: string | RouteSimplifiedOptions, params: ParameterDefinitionMap, handler: RouteHandler) {
+    return this._factory(path, 'PUT', descOrOptions, params, handler);
   }
-  static POST(path: string, desc: string, params: ParameterDefinitionMap, handler: RouteHandler) {
-    return this._factory(path, 'POST', desc, params, handler);
+  static POST(path: string, descOrOptions: string | RouteSimplifiedOptions, params: ParameterDefinitionMap, handler: RouteHandler) {
+    return this._factory(path, 'POST', descOrOptions, params, handler);
   }
-  static DELETE(path: string, desc: string, params: ParameterDefinitionMap, handler: RouteHandler) {
-    return this._factory(path, 'DELETE', desc, params, handler);
+  static DELETE(path: string, descOrOptions: string | RouteSimplifiedOptions, params: ParameterDefinitionMap, handler: RouteHandler) {
+    return this._factory(path, 'DELETE', descOrOptions, params, handler);
   }
-  static OPTIONS(path: string, desc: string, params: ParameterDefinitionMap, handler: RouteHandler) {
-    return this._factory(path, 'OPTIONS', desc, params, handler);
+  static OPTIONS(path: string, descOrOptions: string | RouteSimplifiedOptions, params: ParameterDefinitionMap, handler: RouteHandler) {
+    return this._factory(path, 'OPTIONS', descOrOptions, params, handler);
   }
-  static HEAD(path: string, desc: string, params: ParameterDefinitionMap, handler: RouteHandler) {
-    return this._factory(path, 'HEAD', desc, params, handler);
+  static HEAD(path: string, descOrOptions: string | RouteSimplifiedOptions, params: ParameterDefinitionMap, handler: RouteHandler) {
+    return this._factory(path, 'HEAD', descOrOptions, params, handler);
   }
 
-  private static _factory(path: string, method: HttpMethod, desc: string, params: ParameterDefinitionMap, handler: RouteHandler) {
-    return new this({ path, method, desc, params, handler });
+  private static _factory(path: string, method: HttpMethod, descOrOptions: string | RouteSimplifiedOptions, params: ParameterDefinitionMap, handler: RouteHandler) {
+    if (typeof descOrOptions === "string") {
+      descOrOptions = { desc: descOrOptions };
+    }
+    return new this({ path, method, desc: descOrOptions.desc, operationId: descOrOptions.operationId, params, handler });
   }
+}
+
+export interface RouteSimplifiedOptions {
+  desc?: string;
+  operationId?: string;
 }
 
 
@@ -46,6 +55,10 @@ export interface RouteOptions {
   path: string;
   method: HttpMethod;
   desc: string;
+  /**
+   * Human readable operationId of given route
+   */
+  operationId?: string;
   params?: ParameterDefinitionMap;
   handler: RouteHandler;
 }

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -97,7 +97,7 @@ export class SwaggerGenerator {
             "description": "Success"
           }
         },
-        operationId: this.routesToOperationId(corgiPath, endRoute.method),
+        operationId: endRoute.operationId || this.routesToOperationId(corgiPath, endRoute.method),
       };
 
       switch (endRoute.method) {


### PR DESCRIPTION
**Old Behavior**
1. OperationId always generated from API path

**New Behavior**
1. Developer can customize OperationId


GET /cards/:cardId/interests/:interest become
GetCardsCardIdInterestsInterest, which is ugly and not understandable.
instead, now you can customize it to be "GetCardInterest". 