### PR TITLE
v1.4.1 release fix swagger bug of body parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vingle-corgi",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Restful HTTP Framework for AWS Lambda - AWS API Gateway Proxy Integration",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",
@@ -31,6 +31,7 @@
     "@types/underscore.string": "0.0.30",
     "aws-xray-sdk-core": "1.1.2",
     "joi": "10.5.2",
+    "joi-to-json-schema": "3.0.0",
     "joi-to-swagger": "1.1.0",
     "lodash": "4.17.4",
     "path-to-regexp": "1.7.0",

--- a/src/swagger/__test__/index_spec.ts
+++ b/src/swagger/__test__/index_spec.ts
@@ -5,14 +5,14 @@ import {
   Routes,
   Router,
   Parameter,
-} from '../index';
+} from '../../index';
 
 import {
   SwaggerGenerator,
   SwaggerRoute,
-} from '../swagger';
+} from '../index';
 
-import * as LambdaProxy from '../lambda-proxy';
+import * as LambdaProxy from '../../lambda-proxy';
 
 import * as Joi from 'joi';
 
@@ -26,6 +26,9 @@ describe("SwaggerRoute", () => {
     Route.GET('/api/:userId', 'a', {
       userId: Parameter.Path(Joi.number()),
       testerId: Parameter.Query(Joi.number().required()),
+      user: Parameter.Body(Joi.object({
+        name: Joi.string().required(),
+      }))
     }, async function(this: RoutingContext) {
       return this.json({});
     }),
@@ -66,7 +69,7 @@ describe("SwaggerRoute", () => {
     const router = new Router(routes);
     const res = await router.resolve(mockRequest);
 
-    chai.expect(res.statusCode).to.eq(200)
+    chai.expect(res.statusCode).to.eq(200);
     chai.expect(JSON.parse(res.body)).to.deep.eq({
       "info": {
         "title": "TEST API",
@@ -97,7 +100,25 @@ describe("SwaggerRoute", () => {
               "description": "",
               "type": "number",
               "required": true
-            }],
+            }, {
+              "description": "",
+              "in": "body",
+              "name": "user",
+              "required": true,
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              }
+            }
+          ],
             "responses": {
               "200": {
                 "description": "Success"

--- a/src/swagger/joi-to-json-schema.d.ts
+++ b/src/swagger/joi-to-json-schema.d.ts
@@ -1,0 +1,7 @@
+declare module "joi-to-json-schema" {
+  import { Schema } from 'joi';
+  type JSONSchema = any;
+  function convert(joi: Schema, transformer?: (object: JSONSchema) => JSONSchema): JSONSchema;
+
+  export = convert;
+}

--- a/src/swagger/joi-to-swagger.d.ts
+++ b/src/swagger/joi-to-swagger.d.ts
@@ -1,0 +1,11 @@
+declare module "joi-to-swagger" {
+  import * as Joi from 'joi';
+
+  function convert(joi: Joi.Schema): {
+    swagger: {
+      type: string;
+    };
+  };
+
+  export = convert;
+}


### PR DESCRIPTION
**New Behavior**
1. now swagger router generates "valid" body parameter definition for swagger

Currently it doesn't returns "schema", which is how swagger defines body parameter. refer 
https://swagger.io/docs/specification/describing-request-body/ this for further info
