### PR TITLE
v1.4.9 fixes inconsistent middleware execution order

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vingle-corgi",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "description": "Restful HTTP Framework for AWS Lambda - AWS API Gateway Proxy Integration",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",

--- a/src/__test__/router_spec.ts
+++ b/src/__test__/router_spec.ts
@@ -50,7 +50,19 @@ describe("Router", () => {
           ]
         });
 
-        const res = await router.resolve({
+        let res;
+
+        res = await router.resolve({
+          path: '/',
+          httpMethod: 'GET',
+          queryStringParameters: {
+          },
+        } as any, "request-id");
+
+        expect(res.body).to.eq("ABDC");
+
+        // should preserve middleware order
+        res = await router.resolve({
           path: '/',
           httpMethod: 'GET',
           queryStringParameters: {

--- a/src/__test__/routing-context_spec.ts
+++ b/src/__test__/routing-context_spec.ts
@@ -46,7 +46,7 @@ describe("RoutingContext", () => {
           })
         })),
         userId: Parameter.Path(Joi.number()),
-        interest: Parameter.Path(Joi.strict()),
+        interest: Parameter.Path(Joi.string().strict()),
         arrayParameter: Parameter.Query(Joi.array().items(Joi.number().integer())),
       });
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -171,7 +171,7 @@ export class Router {
               let res = await currentRoute.handler.call(routingContext);
 
               // Run after middlewares
-              for (const middleware of _.reverse(router.middlewares)) {
+              for (const middleware of router.middlewares.slice().reverse()) {
                 if (middleware.after)
                   res = await middleware.after(routingContext, res);
               }

--- a/src/routing-context.ts
+++ b/src/routing-context.ts
@@ -6,7 +6,7 @@ import * as qs from 'qs';
 import { ParameterDefinitionMap } from './parameter';
 
 //
-const DefaultJoiValidateOptions = {
+const DefaultJoiValidateOptions: Joi.ValidationOptions = {
   stripUnknown: true,
   presence: 'required',
   abortEarly: false,


### PR DESCRIPTION
Before executing "after hook" of middlewares, we called `_.reverse(router.middlewares)` to call "after hook" of middlewares in reverse order.

But both `_.reverse(array) // LodashStatic.reverse(array)` and `Array.prototype.reverse` **MUTATE** the original array.

For example:

```js
const arr = [1, 2, 3];
arr.reverse(); // or _.reverse(arr);

console.log(arr); // will print "[3, 2, 1]", not "[1, 2, 3]" since it was mutated by reverse method!
```

our `router.middlewares` array was reversed per single request. so it causes inconsistent middleware execution order. 

This PR fixes that bug by simply creating new reference of array using `Array.prototype.slice` method.

Plus, type definition of joi package was updated. there were some breaking changes, our build was broken. i fixed it also