### PR TITLE
Feature/local server

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,23 +26,23 @@
   "devDependencies": {
     "@types/chai": "^4.0.0",
     "@types/chai-as-promised": "^0.0.31",
-    "@types/mocha": "^2.2.41",
-    "chai": "^4.0.1",
-    "chai-as-promised": "^6.0.0",
-    "mocha": "^3.4.2",
-    "typescript": "^2.4.2",
-    "publish": "^0.6.0"
-  },
-  "dependencies": {
     "@types/joi": "^10.4.0",
     "@types/lodash": "^4.14.65",
+    "@types/mocha": "^2.2.41",
     "@types/node": "^7.0.27",
     "@types/qs": "^6.5.0",
     "@types/swagger-schema-official": "2.0.5",
     "@types/underscore.string": "0.0.30",
-    "joi-to-json-schema": "^3.2.0",
+    "chai": "^4.0.1",
+    "chai-as-promised": "^6.0.0",
+    "mocha": "^3.4.2",
+    "publish": "^0.6.0",
+    "typescript": "^2.4.2"
+  },
+  "dependencies": {
     "aws-xray-sdk-core": "^1.1.2",
     "joi": "^10.5.2",
+    "joi-to-json-schema": "^3.2.0",
     "lodash": "^4.17.4",
     "path-to-regexp": "^1.7.0",
     "qs": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "vingle-corgi",
-  "version": "1.4.10",
+  "version": "1.4.11-beta.1",
   "description": "Restful HTTP Framework for AWS Lambda - AWS API Gateway Proxy Integration",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",
+  "bin": {
+    "corgi-local": "./dst/tools/corgi-local-cli.js"
+  },
   "scripts": {
     "clean": "rm -Rf dst",
     "prebuild": "npm run clean",
@@ -24,8 +27,11 @@
   },
   "homepage": "https://github.com/balmbees/corgi#readme",
   "devDependencies": {
+    "@types/bluebird": "^3.5.18",
     "@types/chai": "^4.0.0",
     "@types/chai-as-promised": "^0.0.31",
+    "@types/commander": "^2.11.0",
+    "@types/debug": "0.0.30",
     "@types/joi": "^10.4.0",
     "@types/lodash": "^4.14.65",
     "@types/mocha": "^2.2.41",
@@ -41,9 +47,13 @@
   },
   "dependencies": {
     "aws-xray-sdk-core": "^1.1.2",
+    "bluebird": "^3.5.1",
+    "commander": "^2.11.0",
+    "debug": "^3.1.0",
     "joi": "^10.5.2",
     "joi-to-json-schema": "^3.2.0",
     "lodash": "^4.17.4",
+    "micro": "^9.0.0",
     "path-to-regexp": "^1.7.0",
     "qs": "^6.5.0",
     "swagger-schema-official": "2.0.0-bab6bed",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vingle-corgi",
-  "version": "1.4.11-beta.6",
+  "version": "1.4.11",
   "description": "Restful HTTP Framework for AWS Lambda - AWS API Gateway Proxy Integration",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -32,12 +32,9 @@
     "@types/chai-as-promised": "^0.0.31",
     "@types/commander": "^2.11.0",
     "@types/debug": "0.0.30",
-    "@types/joi": "^10.4.0",
     "@types/lodash": "^4.14.65",
     "@types/mocha": "^2.2.41",
     "@types/node": "^7.0.27",
-    "@types/qs": "^6.5.0",
-    "@types/swagger-schema-official": "2.0.5",
     "@types/underscore.string": "0.0.30",
     "chai": "^4.0.1",
     "chai-as-promised": "^6.0.0",
@@ -46,6 +43,9 @@
     "typescript": "^2.4.2"
   },
   "dependencies": {
+    "@types/joi": "^10.4.0",
+    "@types/qs": "^6.5.0",
+    "@types/swagger-schema-official": "2.0.5",
     "aws-xray-sdk-core": "^1.1.2",
     "bluebird": "^3.5.1",
     "commander": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vingle-corgi",
-  "version": "1.4.11-beta.1",
+  "version": "1.4.11-beta.6",
   "description": "Restful HTTP Framework for AWS Lambda - AWS API Gateway Proxy Integration",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",

--- a/src/tools/corgi-local-cli.ts
+++ b/src/tools/corgi-local-cli.ts
@@ -29,7 +29,7 @@ if (!handlerPath) {
 }
 
 if (!port) {
-  console.error("invalid port number");
+  console.error("missing or invalid port number");
   program.help();
 }
 

--- a/src/tools/corgi-local-cli.ts
+++ b/src/tools/corgi-local-cli.ts
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+import * as BbPromise from "bluebird";
+BbPromise.config({ longStackTraces: true });
+global.Promise = BbPromise;
+
+import * as program from "commander";
+import * as path from "path";
+import { createServer } from "./corgi-local";
+
+const pkg = require("../../package.json");
+
+program
+  .version(pkg.version)
+  .arguments('<handlerPath>')
+  .option('-p, --port [port]', 'Port Number', process.env.PORT)
+  .parse(process.argv);
+
+const [ handlerPath ] = program.args;
+
+const port = parseInt(program.port, 10);
+
+if (!port) {
+  console.error("missing or invalid port number");
+  process.exit(1);
+}
+
+const handlerAbsolutePath = path.isAbsolute(handlerPath) ? handlerPath : path.resolve(process.cwd(), handlerPath);
+const handlerModule = require(handlerAbsolutePath); // tslint:disable-line
+const server = createServer(handlerModule.handler);
+
+server.listen(port, () => {
+  const { address, port } = server.address();
+
+  console.error(`server listening on ${address}:${port}`);
+});

--- a/src/tools/corgi-local-cli.ts
+++ b/src/tools/corgi-local-cli.ts
@@ -4,6 +4,7 @@ import * as BbPromise from "bluebird";
 BbPromise.config({ longStackTraces: true });
 global.Promise = BbPromise;
 
+import * as debug from "debug";
 import * as program from "commander";
 import * as path from "path";
 import { createServer } from "./corgi-local";
@@ -13,24 +14,56 @@ const pkg = require("../../package.json");
 program
   .version(pkg.version)
   .arguments('<handlerPath>')
-  .option('-p, --port [port]', 'Port Number', process.env.PORT)
+  .option('-s, --silent', 'disable verbose log output')
+  .option('-t, --timeout <n>', 'handler timeout duration (default: 20000ms)', (v) => parseInt(v, 10), 20000)
+  .option('-p, --port <n>', 'port number (default: process.env.PORT)', (v) => parseInt(v, 10), parseInt(process.env.PORT, 10))
   .parse(process.argv);
 
 const [ handlerPath ] = program.args;
+const { silent, timeout, port } = program;
+const verbose = !silent;
 
-const port = parseInt(program.port, 10);
-
-if (!port) {
-  console.error("missing or invalid port number");
-  process.exit(1);
+if (!handlerPath) {
+  console.error("handlerPath is required");
+  program.help();
 }
 
+if (!port) {
+  console.error("invalid port number");
+  program.help();
+}
+
+if (!timeout) {
+  console.error("invalid timeout duration");
+  program.help();
+}
+
+
+const LOG_TAG = "corgi-local-cli";
+const log = debug(LOG_TAG);
+
+if (verbose) {
+  log.enabled = true;
+}
+
+
 const handlerAbsolutePath = path.isAbsolute(handlerPath) ? handlerPath : path.resolve(process.cwd(), handlerPath);
-const handlerModule = require(handlerAbsolutePath); // tslint:disable-line
-const server = createServer(handlerModule.handler);
+let handlerModule;
+try {
+  handlerModule = require(handlerAbsolutePath); // tslint:disable-line
+} catch (e) {
+  console.error(e.message);
+  log(e.stack);
+  program.help();
+}
+
+const server = createServer(handlerModule.handler, {
+  verbose,
+  timeout,
+});
 
 server.listen(port, () => {
   const { address, port } = server.address();
 
-  console.error(`server listening on ${address}:${port}`);
+  log(`server listening on ${address}:${port}`);
 });

--- a/src/tools/corgi-local.ts
+++ b/src/tools/corgi-local.ts
@@ -11,9 +11,17 @@ const micro = require("micro"); // tslint:disable-line
 
 export function createServer(
   handler: (event: LambdaProxy.Event, context: LambdaProxy.Context) => void,
+  options: {
+    verbose?: boolean,
+    timeout?: number,
+  } = {},
 ): http.Server {
   const LOG_TAG = "corgi-local";
   const log = debug(LOG_TAG);
+
+  if (options.verbose) {
+    log.enabled = true;
+  }
 
   return micro(async function(req: http.IncomingMessage, res: http.ServerResponse) {
     log(`${req.method} ${req.url}`);
@@ -53,7 +61,7 @@ export function createServer(
 
           resolve(handlerResponse);
         },
-        getRemainingTimeInMillis: () => 20000,
+        getRemainingTimeInMillis: () => options.timeout || 30 * 1000,
       } as any);
     });
 

--- a/src/tools/corgi-local.ts
+++ b/src/tools/corgi-local.ts
@@ -1,0 +1,100 @@
+// tslint:disable
+
+import * as BbPromise from "bluebird";
+import * as debug from "debug";
+import * as http from "http";
+import * as URL from "url";
+
+import * as LambdaProxy from "../lambda-proxy";
+
+const micro = require("micro"); // tslint:disable-line
+
+export function createServer(
+  handler: (event: LambdaProxy.Event, context: LambdaProxy.Context) => void,
+): http.Server {
+  const LOG_TAG = "corgi-local";
+  const log = debug(LOG_TAG);
+
+  return micro(async function(req: http.IncomingMessage, res: http.ServerResponse) {
+    log(`${req.method} ${req.url}`);
+
+    const url = URL.parse(req.url!, true);
+    const body = await micro.text(req);
+
+    const response = await new BbPromise<LambdaProxy.Response>((resolve, reject) => {
+      handler({
+        resource: "Corgi-Simulator",
+        path: url.pathname,
+        httpMethod: req.method,
+        headers: req.headers,
+        queryStringParameters: url.query,
+        requestContext: {
+          resourceId: "request-random-id",
+        },
+        body,
+      } as any, {
+        functionName: "some name",
+        functionVersion: "v1.0",
+        invokedFunctionArn: "arn",
+        memoryLimitInMB: 1024,
+        awsRequestId: "random id",
+        logGroupName: "log group",
+        logStreamName: "log stream",
+        succeed: (handlerResponse: LambdaProxy.Response) => {
+          resolve(handlerResponse);
+        },
+        fail: (e: Error) => {
+          reject(e);
+        },
+        done: (e: Error, handlerResponse: LambdaProxy.Response) => {
+          if (e) {
+            return reject(e);
+          }
+
+          resolve(handlerResponse);
+        },
+        getRemainingTimeInMillis: () => 20000,
+      } as any);
+    });
+
+    // set headers if specified
+    const headers = transformResponseHeaders(response.headers || {});
+    Object.keys(headers).forEach((fieldName) => {
+      const value = headers[fieldName];
+
+      res.setHeader(fieldName, value);
+    });
+
+    micro.send(res, response.statusCode, response.body);
+  });
+}
+
+function transformResponseHeaders(headers: { [fieldName: string]: string }) {
+  return Object.keys(headers)
+    .reduce((hash, fieldName) => {
+      const groupKey = fieldName.toLowerCase();
+      const value = headers[fieldName];
+
+      if (!hash[groupKey]) {
+        hash[groupKey] = value;
+
+        return hash;
+      }
+
+      if (typeof hash[groupKey] === "string") {
+        const oldValue = hash[groupKey] as string;
+
+        hash[groupKey] = [ oldValue, value ];
+        return hash;
+      }
+
+      if (hash[groupKey] instanceof Array) {
+        const oldValue = hash[groupKey] as string[];
+        oldValue.push(value);
+
+        return hash;
+      }
+
+      return hash;
+    }, {} as { [fieldName: string]: string | string[] });
+}


### PR DESCRIPTION
# What's Changes

## New Feature: local server for corgi

### [Screencast (Asciinema)](https://asciinema.org/a/f3tCW8Se4HRpHFyJBiNcOkPnJ)

Now corgi shipped with its local server to support more easier development.
basically, local server is separated to two parts: `corgi-local.ts` and `corgi-local-cli.ts`

`corgi-local.ts` exports `createServer` function. this function takes corgi handler, and returns instance of [`http.Server` class](https://nodejs.org/docs/latest-v6.x/api/http.html#http_class_http_server) which is wrapped by [zeit/micro](https://github.com/zeit/micro).
so corgi developers can extend local server if needed.

`corgi-local-cli.ts` is simple cli program.
it just takes some configurations from its command arguments, creates new server using `createServer` function from `corgi-local`, and listen on specified port. that's all.

`corgi-local-cli.ts` is exposed to `corgi-local` executable binary.


<img width="1102" alt="2017-11-02 1 15 09" src="https://user-images.githubusercontent.com/2101743/32285960-5116ccc2-bf6f-11e7-8937-bb08d6766113.png">


