### PR TITLE
v1.5.2-beta.0 Make ability to set body parameter as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vingle-corgi",
-  "version": "1.5.1",
+  "version": "1.5.2-beta.0",
   "description": "Restful HTTP Framework for AWS Lambda - AWS API Gateway Proxy Integration",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",

--- a/src/swagger/__test__/index_spec.ts
+++ b/src/swagger/__test__/index_spec.ts
@@ -202,7 +202,7 @@ describe("SwaggerRoute", () => {
                           },
                         }
                       },
-                      "required":true
+                      "required": false
                   }
                 ],
                 "responses":{

--- a/src/swagger/__test__/index_spec.ts
+++ b/src/swagger/__test__/index_spec.ts
@@ -202,7 +202,7 @@ describe("SwaggerRoute", () => {
                           },
                         }
                       },
-                      "required": false
+                      "required": true
                   }
                 ],
                 "responses":{

--- a/src/swagger/index.ts
+++ b/src/swagger/index.ts
@@ -131,7 +131,7 @@ export class SwaggerGenerator {
                   schema: joiSchema,
                   // current joi typing doesn't have type definition for flags
                   // @see https://github.com/hapijs/joi/blob/v12/lib/types/any/index.js#L48-L64
-                  required: ((joiSchemaMetadata.flags || {}) as any).presence === "required",
+                  required: ((joiSchemaMetadata.flags || {}) as any).presence !== "optional",
                 };
                 return param;
               } else {

--- a/src/swagger/index.ts
+++ b/src/swagger/index.ts
@@ -122,13 +122,16 @@ export class SwaggerGenerator {
           } else {
             return _.map(route.params, (paramDef, name) => {
               if (paramDef.in === "body") {
+                const joiSchemaMetadata = paramDef.def.describe();
                 const joiSchema = JoiToSwaggerSchema(paramDef.def);
                 const param: Swagger.Parameter = {
                   in: paramDef.in,
                   name: name,
                   description: '',
                   schema: joiSchema,
-                  required: true
+                  // current joi typing doesn't have type definition for flags
+                  // @see https://github.com/hapijs/joi/blob/v12/lib/types/any/index.js#L48-L64
+                  required: ((joiSchemaMetadata.flags || {}) as any).presence === "required",
                 };
                 return param;
               } else {


### PR DESCRIPTION
### Summary

This PR proposes that Body Parameter can be optional if needed.
currently body parameter is always required even Joi schema defined as optional, but this pr changes this behavior to respect the presence (e.g. required / optional)  of joi schema definition.

### Breaking Changes

This PR could make impact to related projects (e.g. our swagger-codegen based service sdk), because most of our body parameter are defined as optional since joi assign default value of presence as optional. so be careful before merging this PR.