### PR TITLE
v1.7.1 set query parameter as optional only if explicitly defined

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vingle-corgi",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vingle-corgi",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Restful HTTP Framework for AWS Lambda - AWS API Gateway Proxy Integration",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",

--- a/src/swagger/__test__/index_spec.ts
+++ b/src/swagger/__test__/index_spec.ts
@@ -163,6 +163,7 @@ describe("SwaggerRoute", () => {
                       "name":"testerId",
                       "description":"",
                       "type":"number",
+                      "required": true
                   },
                   {
                       "in":"query",
@@ -171,7 +172,8 @@ describe("SwaggerRoute", () => {
                       "type":"array",
                       "items":{
                         "type":"number",
-                      }
+                      },
+                      "required": true
                   },
                   {
                       "in":"body",

--- a/src/swagger/index.ts
+++ b/src/swagger/index.ts
@@ -121,8 +121,9 @@ export class SwaggerGenerator {
             });
           } else {
             return _.map(route.params, (paramDef, name) => {
+              const joiSchemaMetadata = paramDef.def.describe();
+
               if (paramDef.in === "body") {
-                const joiSchemaMetadata = paramDef.def.describe();
                 const joiSchema = JoiToSwaggerSchema(paramDef.def);
                 const param: Swagger.Parameter = {
                   in: paramDef.in,
@@ -144,6 +145,8 @@ export class SwaggerGenerator {
 
                 if (paramDef.in === 'path') {
                   param.required = true;
+                } else { // query param
+                  param.required = ((joiSchemaMetadata.flags || {}) as any).presence !== "optional"
                 }
 
                 return param;


### PR DESCRIPTION
Like #23, Now query string can be optional in swagger doc

Example:

![2018-01-12 11 17 45](https://user-images.githubusercontent.com/2101743/34878973-fd75cc54-f7ee-11e7-8aa5-41440b65e9ac.png)

![2018-01-12 11 17 21](https://user-images.githubusercontent.com/2101743/34878981-05a65e84-f7ef-11e7-9263-b22563ca9029.png)


- ref: BACKEND-1012