### PR TITLE
Fix test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,9 @@
       "integrity": "sha512-dJJVoGihrx0CQFVTkGSxvuJjfkliBa1SlhUTmvFzdT9eC8NwcIJRJafqSQkC5nb1BH+UHCT+2nVZ515k7hE2Sg=="
     },
     "@types/lodash": {
-      "version": "4.14.91",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.91.tgz",
-      "integrity": "sha512-k+nc3moSlAaXacyvz4/c6D9lnUeI6AKsLvkXFuNzUEEqMw7sjDnLW2GqlJ4nyFgMX/p+QzvVG6zRoDo4lJIV5g=="
+      "version": "4.14.109",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.109.tgz",
+      "integrity": "sha512-hop8SdPUEzbcJm6aTsmuwjIYQo1tqLseKCM+s2bBqTU2gErwI4fE+aqUVOlscPSQbKHKgtMMPoC+h4AIGOJYvw=="
     },
     "@types/mocha": {
       "version": "2.2.45",
@@ -54,8 +54,7 @@
       "integrity": "sha1-n+SbQLHQM/1zvrt7tpz6jL8wufE="
     },
     "@types/underscore": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.8.1.tgz",
+      "version": "https://registry.npmjs.org/@types/underscore/-/underscore-1.8.1.tgz",
       "integrity": "sha1-v11oDyQncoTU5C/thr2G5aWaRKQ="
     },
     "@types/underscore.string": {
@@ -63,7 +62,7 @@
       "resolved": "https://registry.npmjs.org/@types/underscore.string/-/underscore.string-0.0.30.tgz",
       "integrity": "sha1-sCdUjHOXvQ3ikL5wyfYOs07+ORo=",
       "requires": {
-        "@types/underscore": "1.8.1"
+        "@types/underscore": "https://registry.npmjs.org/@types/underscore/-/underscore-1.8.1.tgz"
       }
     },
     "@vingle/joi-to-json-schema": {
@@ -438,7 +437,7 @@
       "requires": {
         "class-validator": "0.7.3",
         "debug": "3.1.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "openapi3-ts": "0.6.2",
         "reflect-metadata": "0.1.12",
         "tslib": "1.9.0"
@@ -705,7 +704,7 @@
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.5"
+            "lodash": "4.17.10"
           }
         }
       }
@@ -1150,9 +1149,9 @@
       "dev": true
     },
     "lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash.pad": {
       "version": "4.5.1",
@@ -2560,9 +2559,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.3.tgz",
+      "integrity": "sha512-K7g15Bb6Ra4lKf7Iq2l/I5/En+hLIHmxWZGq3D4DIRNFxMNV6j2SHSvDOqs2tGd4UvD/fJvrwopzQXjLrT7Itw==",
       "dev": true
     },
     "uid-number": {

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
     "chai-as-promised": "^7.1.1",
     "mocha": "^3.4.2",
     "publish": "^0.6.0",
-    "typescript": "^2.4.2"
+    "typescript": "^2.8.3"
   },
   "dependencies": {
     "@types/joi": "^13.0.2",
-    "@types/lodash": "^4.14.65",
+    "@types/lodash": "^4.14.109",
     "@types/node": "^7.0.27",
     "@types/qs": "^6.5.0",
     "@types/swagger-schema-official": "2.0.5",
@@ -48,7 +48,7 @@
     "class-validator": "^0.7.3",
     "class-validator-jsonschema": "^1.1.0",
     "joi": "^13.0.2",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "path-to-regexp": "^1.7.0",
     "qs": "^6.5.0",
     "swagger-schema-official": "2.0.0-bab6bed",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prebuild": "npm run clean",
     "build": "tsc -d",
     "prepublish": "npm run build",
-    "pretest": "npm run build",
+    "pretest": "npm run build -- -p ./tsconfig.test.json",
     "ci:publish": "publish",
     "test": "mocha dst/**/__test__/**/*_spec.js"
   },

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "noImplicitAny": true,
+    "sourceMap": true,
+    "outDir": "dst",
+    "strict": false,
+    "strictNullChecks": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "lib": [
+      "dom",
+      "es2015",
+      "esnext.asynciterable"
+    ]
+  },
+  "include": [
+    "src/**/*"
+  ]
+}


### PR DESCRIPTION
## Add tsconfg.test.json
Test files are excluded in tsconfig.json

## Fix entity array schema
class-validator-jsonschema returns new object of schema.
It is hard to update properties of the converted schema.
Refer to: https://github.com/epiphone/class-validator-jsonschema/blob/master/src/index.ts#L72

Petstore(swagger-ui) can notify`$refs must reference a valid location in the document`.
We don't need to get the runtime error`${elementModelName} must be decorated with ClassValidator`.
