### PR TITLE
v1.14.0 release Refactor Namespace / Middleware Relations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vingle-corgi",
-  "version": "1.12.1",
+  "version": "1.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vingle-corgi",
-  "version": "1.12.1",
+  "version": "1.14.0",
   "description": "Restful HTTP Framework for AWS Lambda - AWS API Gateway Proxy Integration",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",

--- a/src/__test__/e2e/middleware_api_spec.ts
+++ b/src/__test__/e2e/middleware_api_spec.ts
@@ -1,0 +1,77 @@
+import {
+  Response,
+  Route,
+  Namespace,
+  Routes,
+  Router,
+  Parameter,
+  Middleware,
+  MiddlewareAfterOptions,
+} from '../../index';
+import * as Joi from 'joi';
+
+
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+chai.use(chaiAsPromised);
+
+describe("Calling complex middleware connected API", () => {
+  it("should run middleware after exception handler", async () => {
+    const router = new Router(
+      [
+        new Namespace('/api/:userId', {
+          params: {
+            userId: Joi.number()
+          },
+          async exceptionHandler(error: Error) {
+            // 2
+            return this.json(
+              {
+                error: error.message,
+              },
+              500
+            );
+          },
+          children: [
+            new Route({
+              path: '/followers',
+              method: 'GET',
+              operationId: "getFollowers",
+              desc: 'List of users that following me',
+              handler: async function () {
+                // 1
+                throw new Error(`Error: ${this.params.userId}`);
+              }
+            }),
+          ]
+        })
+      ], {
+        middlewares: [
+          new (class TestMiddleware extends Middleware<void> {
+            public async after(options: MiddlewareAfterOptions<void>): Promise<Response> {
+              const { response } = options;
+              // 3
+              if (response.statusCode === 500) {
+                response.headers["error"] = "XX";
+              }
+              return options.response;
+            }
+          })()
+        ]
+      }
+    );
+    const res = await router.resolve({
+      path: "/api/33/followers",
+      httpMethod: 'GET'
+    } as any, { timeout: 10000 });
+
+    chai.expect(res).to.deep.eq({
+      statusCode: 500,
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'error': 'XX'
+      },
+      body: JSON.stringify({ error: `Error: 33`}),
+    });
+  });
+});


### PR DESCRIPTION
Old Behavior:
- When exception raised, the error gets passed to parent namespaces exceptionHandlers.
- Middlewares *after* ignored.

New Behavior
- When exception raised, the error gets passed to parent namespaces *exceptionHandlers*.
- when *exceptionHandler* catches it and generate Response, Middlewares *after get executed with this Response

Thus, for example, if there is Middleware that set CORS headers for Route's Response it used to not be called if route raises an exception. Now, the middleware will be called even when route raise exception and exceptionHandler generated Response based on that exception

### Caution
this means now middleware after could receive "failed" response. so you've got to be careful about accessing Response from middleware's *after*

```
class TestMiddleware extends Middleware {
  async after(options: MiddlewareAfterOptions<undefined>): Promise<Response> {
    const body = JSON.parse(options.response.body)
    // do something with body..
    return options.response;
  }
}
```
this use to be pretty safe code since when the response is generated by exceptionHandler, after won't be called anyway. 
but now it's safer to do,
```
class TestMiddleware extends Middleware {
  async after(options: MiddlewareAfterOptions<undefined>): Promise<Response> {
    if (options.response.statusCode === 200) {
      const body = JSON.parse(options.response.body)
      // do something with body..
    }
    return options.response;
  }
}
```

