### PR TITLE
Feature/backend 1482

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,15 +10,6 @@
       "integrity": "sha512-Ejh1AXTY8lm+x91X/yar3G2z4x9RyKwdTVdyyu7Xj3dNB35fMNCnEWqTO9FgS3zjzlRNqk1MruYhgb8yhRN9rA==",
       "dev": true
     },
-    "@types/chai-as-promised": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.0.tgz",
-      "integrity": "sha512-MFiW54UOSt+f2bRw8J7LgQeIvE/9b4oGvwU7XW30S9QGAiHGnU/fmiOprsyMkdmH2rl8xSPc0/yrQw8juXU6bQ==",
-      "dev": true,
-      "requires": {
-        "@types/chai": "4.0.10"
-      }
-    },
     "@types/joi": {
       "version": "13.0.2",
       "resolved": "https://registry.npmjs.org/@types/joi/-/joi-13.0.2.tgz",
@@ -376,15 +367,6 @@
         }
       }
     },
-    "chai-as-promised": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
-      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
-      "dev": true,
-      "requires": {
-        "check-error": "1.0.2"
-      }
-    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -402,12 +384,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz",
       "integrity": "sha1-5upnvSR+EHESmDt6sEee02KAAIE=",
-      "dev": true
-    },
-    "check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "chmodr": {
@@ -2559,9 +2535,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.3.tgz",
-      "integrity": "sha512-K7g15Bb6Ra4lKf7Iq2l/I5/En+hLIHmxWZGq3D4DIRNFxMNV6j2SHSvDOqs2tGd4UvD/fJvrwopzQXjLrT7Itw==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
       "dev": true
     },
     "uid-number": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vingle-corgi",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vingle-corgi",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Restful HTTP Framework for AWS Lambda - AWS API Gateway Proxy Integration",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -28,13 +28,11 @@
   "homepage": "https://github.com/balmbees/corgi#readme",
   "devDependencies": {
     "@types/chai": "^4.0.0",
-    "@types/chai-as-promised": "^7.1.0",
     "@types/mocha": "^2.2.41",
     "chai": "^4.0.1",
-    "chai-as-promised": "^7.1.1",
     "mocha": "^3.4.2",
     "publish": "^0.6.0",
-    "typescript": "^2.8.3"
+    "typescript": "^2.9.2"
   },
   "dependencies": {
     "@types/joi": "^13.0.2",

--- a/src/__test__/e2e/complex_api_spec.ts
+++ b/src/__test__/e2e/complex_api_spec.ts
@@ -89,11 +89,71 @@ describe("Calling complex API", () => {
   });
 });
 
+describe("Calling complex API", () => {
+  it("should pass paramseters to child namespaces", async () => {
+    const befores: any[] = [];
+    const routes: Routes = [
+      new Namespace('/a/:a', {
+        params: {
+          a: Joi.number()
+        },
+        async before() {
+          befores.push({ a: this.params.a });
+          this.params.foo = { a: this.params.a };
+        },
+        children: [
+          new Namespace('/b/:b', {
+            params: {
+              b: Joi.number(),
+            },
+            async before() {
+              befores.push({ a: this.params.a, b: this.params.b });
+              this.params.bar = { a: this.params.a, b: this.params.b };
+            },
+            children: [
+              Route.GET('/', { operationId: "get" }, {}, async function () {
+                return this.json([
+                  this.params.foo,
+                  this.params.bar,
+                ]);
+              }),
+            ]
+          })
+        ]
+      })
+    ];
+
+    const router = new Router(routes);
+    const res = await router.resolve({
+      path: "/a/10/b/20",
+      httpMethod: 'GET'
+    } as any, { timeout: 10000 });
+
+    expect(res.statusCode).to.be.eq(200);
+    expect(befores).to.deep.eq([
+      {
+        "a": 10,
+      }, {
+        "a": 10,
+        "b": 20,
+      }
+    ]);
+    expect(JSON.parse(res.body)).to.be.deep.eq([
+      {
+        "a": 10,
+      }, {
+        "a": 10,
+        "b": 20,
+      }
+    ]);
+  });
+});
+
 describe("Global Error Handling", () => {
   it("should fail, and handled by parent namespace error handler", async () => {
     const routes: Routes = [
       new Namespace('/api', {
-        exceptionHandler: async function(error: any) {
+        async exceptionHandler(error: any) {
           if (error.name == 'ValidationError') {
             const validationError = error as Joi.ValidationError;
             return this.json(

--- a/src/__test__/e2e/complex_api_spec.ts
+++ b/src/__test__/e2e/complex_api_spec.ts
@@ -1,3 +1,5 @@
+import { expect } from "chai";
+
 import {
   Route,
   Namespace,
@@ -6,11 +8,6 @@ import {
   Parameter,
 } from '../../index';
 import * as Joi from 'joi';
-
-
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
-chai.use(chaiAsPromised);
 
 describe("Calling complex API", () => {
   it("should exist", async () => {
@@ -78,7 +75,7 @@ describe("Calling complex API", () => {
       }
     } as any, { timeout: 10000 });
 
-    chai.expect(res).to.deep.eq({
+    expect(res).to.deep.eq({
       statusCode: 200,
       headers: { 'Content-Type': 'application/json; charset=utf-8' },
       body: JSON.stringify({
@@ -135,7 +132,7 @@ describe("Global Error Handling", () => {
       }
     } as any, { timeout: 10000 });
 
-    chai.expect(res).to.deep.eq({
+    expect(res).to.deep.eq({
       statusCode: 422,
       headers: { 'Content-Type': 'application/json; charset=utf-8' },
       body: JSON.stringify({ errors: [ '"testId" is required', '"otherError" is required' ] }),

--- a/src/__test__/e2e/entity_presenter_spec.ts
+++ b/src/__test__/e2e/entity_presenter_spec.ts
@@ -1,3 +1,5 @@
+import { expect } from "chai";
+
 import {
   DataLayoutPresenter,
   EntityPresenterFactory,
@@ -9,12 +11,7 @@ import {
 } from '../../index';
 import * as Joi from 'joi';
 
-
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
-chai.use(chaiAsPromised);
-
-import { TestEntity, TestAliasEntity, TestStatEntity } from "../entity";
+import { TestEntity, TestAliasEntity } from "../entity";
 
 const arrayPresenter = EntityPresenterFactory.createArray(TestEntity, (input: number[]) => {
   return input.map(i => {
@@ -76,7 +73,7 @@ describe("Calling complex API", () => {
       httpMethod: 'GET',
     } as any, { timeout: 10000 });
 
-    chai.expect(res).to.deep.eq({
+    expect(res).to.deep.eq({
       statusCode: 200,
       headers: { 'Content-Type': 'application/json; charset=utf-8' },
       body: JSON.stringify({
@@ -101,9 +98,9 @@ describe("Calling complex API", () => {
       }
     } as any, { timeout: 10000 });
 
-    chai.expect(res["statusCode"]).to.eq(200);
+    expect(res["statusCode"]).to.eq(200);
     // This thing must be validated by https://editor.swagger.io
-    chai.expect(JSON.parse(res["body"])).to.deep.eq({
+    expect(JSON.parse(res["body"])).to.deep.eq({
       "swagger": "2.0",
       "info": {
         "title": "InterestService",

--- a/src/__test__/e2e/middleware_api_spec.ts
+++ b/src/__test__/e2e/middleware_api_spec.ts
@@ -1,19 +1,14 @@
+import { expect } from "chai";
+
 import {
   Response,
   Route,
   Namespace,
-  Routes,
   Router,
-  Parameter,
   Middleware,
   MiddlewareAfterOptions,
 } from '../../index';
 import * as Joi from 'joi';
-
-
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
-chai.use(chaiAsPromised);
 
 describe("Calling complex middleware connected API", () => {
   it("should run middleware after exception handler", async () => {
@@ -65,7 +60,7 @@ describe("Calling complex middleware connected API", () => {
       httpMethod: 'GET'
     } as any, { timeout: 10000 });
 
-    chai.expect(res).to.deep.eq({
+    expect(res).to.deep.eq({
       statusCode: 500,
       headers: {
         'Content-Type': 'application/json; charset=utf-8',

--- a/src/__test__/namespace_spec.ts
+++ b/src/__test__/namespace_spec.ts
@@ -1,12 +1,7 @@
+import { expect } from "chai";
+
 import { Route } from '../route';
 import { Namespace } from '../namespace';
-import { RoutingContext } from '../routing-context';
-import * as Joi from 'joi';
-
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
-chai.use(chaiAsPromised);
-const expect = chai.expect;
 
 describe("Namespace", () => {
   describe("#constructor", () => {
@@ -30,7 +25,4 @@ describe("Namespace", () => {
       }).to.throw(Error);
     });
   });
-
-
 });
-

--- a/src/__test__/root-namespace_spec.ts
+++ b/src/__test__/root-namespace_spec.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 
 import { Route } from '../route';
 import { Router } from '../router';
-import { RootNamespace } from '../root-namespace';
+import { RootNamespace, StandardError } from '../root-namespace';
 
 class CustomError extends Error {
 
@@ -10,27 +10,59 @@ class CustomError extends Error {
 
 describe("RootNamespace", () => {
   describe("#exceptionHandler", () => {
-    it("should handler general error and build json response", async () => {
-      const rootNamespace = new RootNamespace([
-        Route.GET('/test', { operationId: "test" }, {}, async function() {
-          throw new CustomError("TEST ERROR");
-        })
-      ]);
+    context("with custom error", () => {
+      it("should handler general error and build json response", async () => {
+        const rootNamespace = new RootNamespace([
+          Route.GET('/test', { operationId: "test" }, {}, async function() {
+            throw new CustomError("TEST ERROR");
+          })
+        ]);
 
-      const router = new Router([rootNamespace]);
-      const res = await router.resolve({
-        path: '/test',
-        httpMethod: 'GET',
-      } as any, { requestId: "request-id", timeout: 10000 });
+        const router = new Router([rootNamespace]);
+        const res = await router.resolve({
+          path: '/test',
+          httpMethod: 'GET',
+        } as any, { requestId: "request-id", timeout: 10000 });
 
-      expect(JSON.parse(res["body"])).to.deep.eq({
-        'error':{
-          'id':'request-id',
-          'summary':'Ooops something went wrong',
-          'message':'Error : TEST ERROR'
-        }
+        expect(JSON.parse(res["body"])).to.deep.eq({
+          'error':{
+            'id':'request-id',
+            'code': 'Error',
+            'message':'TEST ERROR'
+          }
+        });
+        expect(res.statusCode).to.be.eq(500);
       });
-      expect(res.statusCode).to.be.eq(500);
+    });
+
+    context("with standard error", () => {
+      it("should handler general error and build json response", async () => {
+        const rootNamespace = new RootNamespace([
+          Route.GET('/test', { operationId: "test" }, {}, async function() {
+            throw new StandardError(422, {
+              code: "INVALID_REQUEST", message: "this request is invalid", metadata: { test: 1 }
+            });
+          })
+        ]);
+
+        const router = new Router([rootNamespace]);
+        const res = await router.resolve({
+          path: '/test',
+          httpMethod: 'GET',
+        } as any, { requestId: "request-id", timeout: 10000 });
+
+        expect(JSON.parse(res["body"])).to.deep.eq({
+          'error':{
+            'id': 'request-id',
+            'code': 'INVALID_REQUEST',
+            'message': 'this request is invalid',
+            'metadata': {
+              'test': 1,
+            },
+          }
+        });
+        expect(res.statusCode).to.be.eq(422);
+      });
     });
   });
 });

--- a/src/__test__/root-namespace_spec.ts
+++ b/src/__test__/root-namespace_spec.ts
@@ -1,7 +1,4 @@
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
-chai.use(chaiAsPromised);
-const expect = chai.expect;
+import { expect } from "chai";
 
 import { Route } from '../route';
 import { Router } from '../router';

--- a/src/__test__/route_spec.ts
+++ b/src/__test__/route_spec.ts
@@ -1,11 +1,7 @@
+import { expect } from "chai";
+
 import { Route } from '../route';
 import { RoutingContext } from '../routing-context';
-import * as Joi from 'joi';
-
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
-chai.use(chaiAsPromised);
-const expect = chai.expect;
 
 describe("Route", () => {
   describe("#constructor", () => {

--- a/src/__test__/router_spec.ts
+++ b/src/__test__/router_spec.ts
@@ -1,29 +1,21 @@
+import { expect } from "chai";
+
 import {
   Route,
-  RoutingContext,
   Namespace,
-  Routes,
   Router,
-  Parameter,
   Middleware,
   MiddlewareBeforeOptions,
   MiddlewareAfterOptions,
   Response,
   TimeoutError,
 } from '../index';
-import * as Joi from 'joi';
-
-
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
-chai.use(chaiAsPromised);
-const expect = chai.expect;
 
 describe("Router", () => {
   describe("#constructor", () => {
     it("should raise error if there is duplicated operationId", () => {
       expect(() => {
-        const router = new Router([
+        new Router([
           Route.GET('/', { operationId: "getIndex" }, {}, async function () {
             return this.json("");
           }),
@@ -38,7 +30,7 @@ describe("Router", () => {
       expect(() => {
         class TestMiddleware extends Middleware {};
 
-        const router = new Router([
+        new Router([
           Route.GET('/', { operationId: "getIndex" }, {}, async function() {
             return {
               statusCode: 200,
@@ -187,7 +179,7 @@ describe("Router", () => {
         );
       });
 
-      chai.expect(res).to.deep.eq({
+      expect(res).to.deep.eq({
         statusCode: 500,
         headers: { 'Content-Type': 'application/json; charset=utf-8' },
         body: JSON.stringify({

--- a/src/__test__/routing-context_spec.ts
+++ b/src/__test__/routing-context_spec.ts
@@ -1,11 +1,9 @@
+import { expect } from "chai";
+
 import { RoutingContext } from '../routing-context';
 import { Parameter } from '../parameter';
 import * as Joi from 'joi';
 import * as qs from "qs";
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
-chai.use(chaiAsPromised);
-const expect = chai.expect;
 
 describe("RoutingContext", () => {
   describe("#validateAndUpdateParams", () => {

--- a/src/error_response.ts
+++ b/src/error_response.ts
@@ -1,0 +1,17 @@
+export interface StandardErrorResponseBody {
+  error: {
+    id?: string;
+    /**
+     * Developer readable code of error, such as "NOT_FOUND", "WRONG_PASSWORD" ...etc
+     */
+    code: string;
+    /**
+     * Developer readable metadata.
+     */
+    metadata?: object;
+    /**
+     * Human readable Error message, such as "You're not allowed to do this"
+     */
+    message: string;
+  }
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,4 @@
 // List of custom errors
-
 import { Route } from "./route";
 
 export class TimeoutError extends Error {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,5 +10,6 @@ export * from './middleware';
 export * from './middlewares';
 export * from "./route_factories";
 export * from "./errors";
+export * from "./error_response";
 
 export { ClassValidator } from "./route_factories/presenter_route/class_validator";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './namespace';
+export * from './root-namespace';
 export * from './route';
 export * from './router';
 export * from './routing-context';

--- a/src/middlewares/xray-middleware/__test__/index_spec.ts
+++ b/src/middlewares/xray-middleware/__test__/index_spec.ts
@@ -1,12 +1,8 @@
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
-chai.use(chaiAsPromised);
-const expect = chai.expect;
+import { expect } from "chai";
 
 import { XRayMiddleware } from "../index";
 import { RoutingContext } from '../../../routing-context';
 import { Route } from '../../../route';
-
 
 describe(XRayMiddleware.name, () => {
   describe("Constructor", () => {

--- a/src/middlewares/xray-middleware/index.ts
+++ b/src/middlewares/xray-middleware/index.ts
@@ -1,7 +1,5 @@
 import { Middleware, MiddlewareBeforeOptions, MiddlewareAfterOptions } from '../../middleware';
-import { RoutingContext } from '../../routing-context';
-import { Response, Event as LambdaProxyEvent } from '../../lambda-proxy';
-import * as http from 'http';
+import { Response } from '../../lambda-proxy';
 
 const AWSXRay = require("aws-xray-sdk-core");
 interface AWSXRaySegment {

--- a/src/route_factories/presenter_route/__test__/entity_spec.ts
+++ b/src/route_factories/presenter_route/__test__/entity_spec.ts
@@ -1,7 +1,4 @@
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
-chai.use(chaiAsPromised);
-const expect = chai.expect;
+import { expect } from "chai";
 
 import { EntityPresenterFactory } from '../../../index';
 

--- a/src/route_factories/presenter_route/__test__/presenter_route_spec.ts
+++ b/src/route_factories/presenter_route/__test__/presenter_route_spec.ts
@@ -1,7 +1,4 @@
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
-chai.use(chaiAsPromised);
-const expect = chai.expect;
+import { expect } from "chai";
 
 import {
   EntityPresenterFactory,
@@ -54,7 +51,7 @@ describe(PresenterRouteFactory.name, () => {
         httpMethod: 'GET',
       } as any, { timeout: 10000 });
 
-      chai.expect(res).to.deep.eq({
+      expect(res).to.deep.eq({
         statusCode: 200,
         headers: { 'Content-Type': 'application/json; charset=utf-8' },
         body: JSON.stringify({ id: "100", name: "abcd" })

--- a/src/route_factories/presenter_route/entity.ts
+++ b/src/route_factories/presenter_route/entity.ts
@@ -2,10 +2,6 @@ import { Presenter } from "./presenter";
 
 import { ClassValidator, ClassValidatorJSONSchema } from "./class_validator";
 
-function getPropType(target: any, property: string) {
-  return Reflect.getMetadata('design:type', target, property);
-}
-
 export class EntityPresenterFactory {
   private static __schemas: any;
   public static schemas() {

--- a/src/router.ts
+++ b/src/router.ts
@@ -4,7 +4,7 @@ import * as _ from 'lodash';
 import * as LambdaProxy from './lambda-proxy';
 import { Route } from './route';
 import { Routes, Namespace } from './namespace';
-import { RootNamespace, StandardErrorResponseBody } from './root-namespace';
+import { RootNamespace } from './root-namespace';
 import { RoutingContext } from './routing-context';
 import { ParameterInputType } from './parameter';
 import { Middleware, MiddlewareConstructor } from './middleware';

--- a/src/router.ts
+++ b/src/router.ts
@@ -137,7 +137,8 @@ export class Router {
           const runRoute = async (namespaces: Namespace[], route: Route) => {
             try {
               // Run Parent Namespaces
-              for (const namespace of namespaces) {
+              // This is for parameter and before, so Top -> Bottom
+              for (const namespace of namespaces.slice().reverse()) {
                 // Parameter Validation
                 const params = _.mapValues(namespace.params, (schema, name) => {
                   return {
@@ -178,6 +179,7 @@ export class Router {
                 return Promise.reject(error);
               })
             } catch (e) {
+              // This is exception handler, so Bottom -> Top.
               for (const namespace of namespaces) {
                 if (namespace.exceptionHandler) {
                   const res = await namespace.exceptionHandler.call(routingContext, e);

--- a/src/swagger/__test__/index_spec.ts
+++ b/src/swagger/__test__/index_spec.ts
@@ -1,7 +1,8 @@
+import { expect } from "chai";
+
 import {
   Route,
   RoutingContext,
-  Namespace,
   Routes,
   Router,
   Parameter,
@@ -15,11 +16,6 @@ import {
 import * as LambdaProxy from '../../lambda-proxy';
 
 import * as Joi from 'joi';
-
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
-chai.use(chaiAsPromised);
-const expect = chai.expect;
 
 describe("SwaggerRoute", () => {
   const PaginatedUserArraySchema = Joi.object({
@@ -182,10 +178,10 @@ describe("SwaggerRoute", () => {
     const router = new Router(routes);
     const res = await router.resolve(mockRequest, { timeout: 10000 });
 
-    chai.expect(res.statusCode).to.eq(200);
-    chai.expect(JSON.parse(res.body)).to.deep.eq({ "swagger": "2.0", "info": { "title": "TEST API", "version": "1.0.0" }, "host": "api.example.net", "basePath": "/prod/", "schemes": ["https"], "produces": ["application/json; charset=utf-8"], "paths": { "/api/{userId}": { "get": { "description": "a", "produces": ["application/json; charset=utf-8"], "parameters": [{ "in": "path", "name": "userId", "description": "", "type": "integer", "required": true }, { "in": "query", "name": "testerId", "description": "", "type": "number", "required": true }, { "in": "query", "name": "userIds", "description": "", "type": "array", "items": { "type": "number" }, "required": true }, { "in": "body", "name": "user", "description": "", "schema": { "type": "object", "properties": { "name": { "type": "string" }, "tags": { "type": "array", "items": { "type": "object", "properties": { "name": { "type": "string" } }, "required": ["name"] } }, "test": { "type": "object", "properties": {} } }, "required": ["name", "tags", "test"] }, "required": true }], "responses": { "200": { "description": "Success" } }, "operationId": "GetApiUserId" } }, "/api/a": { "post": { "description": "a", "produces": ["application/json; charset=utf-8"], "parameters": [], "responses": { "200": { "description": "Success" } }, "operationId": "GetAPIa" } }, "/api/c": { "get": { "description": "a", "produces": ["application/json; charset=utf-8"], "parameters": [], "responses": { "200": { "description": "Success" } }, "operationId": "GetApiC" } }, "/api/users2": { "get": { "description": "get all users", "produces": ["application/json; charset=utf-8"], "parameters": [], "responses": { "200": { "description": "Success", "schema": { "$ref": "#/definitions/JSONSchema" } } }, "operationId": "GetUsers2" } }, "/api/users": { "get": { "description": "get all users", "produces": ["application/json; charset=utf-8"], "parameters": [], "responses": { "200": { "description": "Success", "schema": { "$ref": "#/definitions/PaginatedUsers" } } }, "operationId": "GetUsers" } } }, "tags": [], "definitions": { "JSONSchema": { "type": "object", "properties": { "checked": { "type": "boolean", "title": "The Checked Schema.", "description": "An explanation about the purpose of this instance.", "default": false }, "dimensions": { "type": "object", "properties": { "width": { "type": "integer", "title": "The Width Schema.", "description": "An explanation about the purpose of this instance.", "default": 0 }, "height": { "type": "integer", "title": "The Height Schema.", "description": "An explanation about the purpose of this instance.", "default": 0 } } }, "id": { "type": "integer", "title": "The Id Schema.", "description": "An explanation about the purpose of this instance.", "default": 0 }, "name": { "type": "string", "title": "The Name Schema.", "description": "An explanation about the purpose of this instance.", "default": "" }, "price": { "type": "number", "title": "The Price Schema.", "description": "An explanation about the purpose of this instance.", "default": 0 }, "tags": { "type": "array", "items": { "type": "string", "title": "The 0 Schema.", "description": "An explanation about the purpose of this instance.", "default": "" } } } }, "PaginatedUsers": { "type": "object", "properties": { "data": { "type": "array", "items": { "type": "object", "properties": { "id": { "type": "integer" }, "username": { "type": "string" } }, "required": ["id", "username"] } } }, "required": ["data"] } } });
+    expect(res.statusCode).to.eq(200);
+    expect(JSON.parse(res.body)).to.deep.eq({ "swagger": "2.0", "info": { "title": "TEST API", "version": "1.0.0" }, "host": "api.example.net", "basePath": "/prod/", "schemes": ["https"], "produces": ["application/json; charset=utf-8"], "paths": { "/api/{userId}": { "get": { "description": "a", "produces": ["application/json; charset=utf-8"], "parameters": [{ "in": "path", "name": "userId", "description": "", "type": "integer", "required": true }, { "in": "query", "name": "testerId", "description": "", "type": "number", "required": true }, { "in": "query", "name": "userIds", "description": "", "type": "array", "items": { "type": "number" }, "required": true }, { "in": "body", "name": "user", "description": "", "schema": { "type": "object", "properties": { "name": { "type": "string" }, "tags": { "type": "array", "items": { "type": "object", "properties": { "name": { "type": "string" } }, "required": ["name"] } }, "test": { "type": "object", "properties": {} } }, "required": ["name", "tags", "test"] }, "required": true }], "responses": { "200": { "description": "Success" } }, "operationId": "GetApiUserId" } }, "/api/a": { "post": { "description": "a", "produces": ["application/json; charset=utf-8"], "parameters": [], "responses": { "200": { "description": "Success" } }, "operationId": "GetAPIa" } }, "/api/c": { "get": { "description": "a", "produces": ["application/json; charset=utf-8"], "parameters": [], "responses": { "200": { "description": "Success" } }, "operationId": "GetApiC" } }, "/api/users2": { "get": { "description": "get all users", "produces": ["application/json; charset=utf-8"], "parameters": [], "responses": { "200": { "description": "Success", "schema": { "$ref": "#/definitions/JSONSchema" } } }, "operationId": "GetUsers2" } }, "/api/users": { "get": { "description": "get all users", "produces": ["application/json; charset=utf-8"], "parameters": [], "responses": { "200": { "description": "Success", "schema": { "$ref": "#/definitions/PaginatedUsers" } } }, "operationId": "GetUsers" } } }, "tags": [], "definitions": { "JSONSchema": { "type": "object", "properties": { "checked": { "type": "boolean", "title": "The Checked Schema.", "description": "An explanation about the purpose of this instance.", "default": false }, "dimensions": { "type": "object", "properties": { "width": { "type": "integer", "title": "The Width Schema.", "description": "An explanation about the purpose of this instance.", "default": 0 }, "height": { "type": "integer", "title": "The Height Schema.", "description": "An explanation about the purpose of this instance.", "default": 0 } } }, "id": { "type": "integer", "title": "The Id Schema.", "description": "An explanation about the purpose of this instance.", "default": 0 }, "name": { "type": "string", "title": "The Name Schema.", "description": "An explanation about the purpose of this instance.", "default": "" }, "price": { "type": "number", "title": "The Price Schema.", "description": "An explanation about the purpose of this instance.", "default": 0 }, "tags": { "type": "array", "items": { "type": "string", "title": "The 0 Schema.", "description": "An explanation about the purpose of this instance.", "default": "" } } } }, "PaginatedUsers": { "type": "object", "properties": { "data": { "type": "array", "items": { "type": "object", "properties": { "id": { "type": "integer" }, "username": { "type": "string" } }, "required": ["id", "username"] } } }, "required": ["data"] } } });
 
-    chai.expect(res.headers).to.include({
+    expect(res.headers).to.include({
       'Access-Control-Allow-Origin': 'https://foo.bar',
       'Access-Control-Allow-Headers': 'Content-Type',
       'Access-Control-Allow-Methods': ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'].join(', '),
@@ -203,8 +199,8 @@ describe("SwaggerRoute", () => {
       }
     } as any, { timeout: 10000 });
 
-    chai.expect(res.statusCode).to.be.eq(204);
-    chai.expect(res.headers).to.include({
+    expect(res.statusCode).to.be.eq(204);
+    expect(res.headers).to.include({
       'Access-Control-Allow-Origin': 'https://www.vingle.net',
       'Access-Control-Allow-Headers': 'Content-Type',
       'Access-Control-Allow-Methods': ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'].join(', '),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "strictNullChecks": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
+    "noUnusedLocals": true,
     "lib": [
       "dom",
       "es2015",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -9,6 +9,7 @@
     "strictNullChecks": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
+    "noUnusedLocals": true,
     "lib": [
       "dom",
       "es2015",


### PR DESCRIPTION
1) 각종 라이브러리 업데이트

2) 이게 중요한데, Standard Error Response를 추가합니다.

```
+          Route.GET('/test', { operationId: "test" }, {}, async function() {
+            throw new StandardError(422, {
+              code: "INVALID_REQUEST", message: "this request is invalid", metadata: { test: 1 }
+            });
+          })
```
사용할때는 이렇게 하면되고, 이 에러는 root-namespace에서 자동적으로
```
+export interface StandardErrorResponseBody {
+  error: {
+    id?: string;
+    /**
+     * Developer readable code of error, such as "NOT_FOUND", "WRONG_PASSWORD" ...etc
+     */
+    code: string;
+    /**
+     * Developer readable metadata.
+     */
+    metadata?: object;
+    /**
+     * Human readable Error message, such as "You're not allowed to do this"
+     */
+    message: string;
+  }
+}
```
이렇게 converting 됩니다. 

즉 앞으로는 error를 throw할때 커스텀한 에러를 만들지 말고, 무조건 StandardError를 throw하도록 통일해야합니다.

위에 있는 필드중 metadata / code는 현재는 사용하는 곳이 없지만, 미래에 
1) HTTP Status Code와 별개로, Client application에서 이해할수 있는 예약된 error code를 만들어야할때
  - 같은 404라도 404가 나오는 이유가 다르고, 그 이유에 따라 client application에서 할수 있는일이 다르거나 할때

2) client application에서 error handling을 위해 추가적인 데이터가 필요한 경우
  - 만약 24시간 이내에는 username을 두번 못바꾸는데, 실패하면 UI에서 "n시간 뒤에 다시 시도하세요" 를 보여주고 싶다 고 한다면
  - statusCode: 422, code: "CHANGES_TOO_OFTEN", metadata: { last_changed_time: Date } 
  같은식으로 만들어서 클라이언트와 code에 다른 metadata의 형식을 약속하면 됩니다.
