### PR TITLE
v1.16.0 add primitive type array support on entity presenter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vingle-corgi",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vingle-corgi",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Restful HTTP Framework for AWS Lambda - AWS API Gateway Proxy Integration",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",

--- a/src/__test__/e2e/entity_presenter_spec.ts
+++ b/src/__test__/e2e/entity_presenter_spec.ts
@@ -174,6 +174,12 @@ describe("Calling complex API", () => {
               "items": {
                 "$ref": "#/definitions/TestStatEntity"
               }
+            },
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           },
           "required": [

--- a/src/__test__/entity.ts
+++ b/src/__test__/entity.ts
@@ -25,4 +25,8 @@ export class TestEntity {
   @ClassValidator.IsOptional()
   @ClassValidator.Validate(ClassValidator.ValidateEntityArray, [TestStatEntity])
   public stats: TestStatEntity[];
+
+  @ClassValidator.IsOptional()
+  @ClassValidator.Validate(ClassValidator.ValidatePrimitiveArray, [String])
+  public names: string[];
 }

--- a/src/route_factories/presenter_route/__test__/entity_spec.ts
+++ b/src/route_factories/presenter_route/__test__/entity_spec.ts
@@ -48,6 +48,12 @@ describe(EntityPresenterFactory.name, () => {
               "items": {
                 "$ref": "#/definitions/TestStatEntity"
               }
+            },
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           },
           "required": [

--- a/src/route_factories/presenter_route/class_validator/class_validator.ts
+++ b/src/route_factories/presenter_route/class_validator/class_validator.ts
@@ -1,3 +1,4 @@
 export * from "class-validator";
 export * from "./is_nullable";
-export * from "./validate_entity_array"
+export * from "./validate_entity_array";
+export * from "./validate_primitive_array";

--- a/src/route_factories/presenter_route/class_validator/validate_primitive_array.ts
+++ b/src/route_factories/presenter_route/class_validator/validate_primitive_array.ts
@@ -1,0 +1,11 @@
+import { ValidatorConstraint, ValidatorConstraintInterface, ValidationArguments } from "class-validator";
+
+@ValidatorConstraint({ name: "primitiveArrayValidation", async: false })
+export class ValidatePrimitiveArray implements ValidatorConstraintInterface {
+  validate(value: any, args: ValidationArguments) {
+    const [ elementClass ] = args.constraints;
+
+    return value instanceof Array &&
+      value.every((el) => el && el.constructor === elementClass);
+  }
+}

--- a/src/route_factories/presenter_route/entity.ts
+++ b/src/route_factories/presenter_route/entity.ts
@@ -30,6 +30,23 @@ export class EntityPresenterFactory {
                   value: elementClass,
                 });
               }
+              case ClassValidator.ValidatePrimitiveArray: {
+                const [ elementClass ] = meta.constraints;
+
+                return {
+                  type: "array",
+                  items: {
+                    type: (() => {
+                      switch (elementClass) {
+                        case Boolean: return "boolean";
+                        case String: return "string";
+                        case Number: return "number";
+                        default: return {}; // equal as any
+                      }
+                    })(),
+                  },
+                };
+              }
               case ClassValidator.IsNullable: {
                 return {
                   // Currently Swagger Spec 2.0 does not support `nullable` attribute


### PR DESCRIPTION
Now developers can define primitive type array using `ValidatePrimitiveArray`.