### PR TITLE
Feature/backend 1879

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vingle-corgi",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vingle-corgi",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vingle-corgi",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Restful HTTP Framework for AWS Lambda - AWS API Gateway Proxy Integration",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vingle-corgi",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Restful HTTP Framework for AWS Lambda - AWS API Gateway Proxy Integration",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",

--- a/src/__test__/root-namespace_spec.ts
+++ b/src/__test__/root-namespace_spec.ts
@@ -34,37 +34,36 @@ describe("RootNamespace", () => {
 
         it("should handler general error and build json response, with encrpyted message", async () => {
           const res = await subject();
-          expect(
-            rootNamespace.errorFormatter.decryptErrorMetadata(JSON.parse(res["body"]).error.metadata)
-          ).to.be.deep.eq({
-            "message": "TEST ERROR",
-            "name": "Error",
-            "stack": [
-              "Error: TEST ERROR",
-              "    at RoutingContext.<anonymous> (/Users/lea/Works/corgi/dst/__test__/root-namespace_spec.js:26:35)",
-              "    at Generator.next (<anonymous>)",
-              "    at /Users/lea/Works/corgi/dst/__test__/root-namespace_spec.js:7:71",
-              "    at new WrappedPromise (/Users/lea/Works/corgi/node_modules/async-listener/es6-wrapped-promise.js:13:18)",
-              "    at __awaiter (/Users/lea/Works/corgi/dst/__test__/root-namespace_spec.js:3:12)",
-              "    at RoutingContext.<anonymous> (/Users/lea/Works/corgi/dst/__test__/root-namespace_spec.js:25:32)",
-              "    at Router.<anonymous> (/Users/lea/Works/corgi/dst/router.js:148:51)",
-              "    at Generator.next (<anonymous>)",
-              "    at /Users/lea/Works/corgi/dst/router.js:7:71",
-              "    at new WrappedPromise (/Users/lea/Works/corgi/node_modules/async-listener/es6-wrapped-promise.js:13:18)",
-              "    at __awaiter (/Users/lea/Works/corgi/dst/router.js:3:12)",
-              "    at runRoute (/Users/lea/Works/corgi/dst/router.js:121:65)",
-              "    at /Users/lea/Works/corgi/dst/router.js:207:60",
-              "    at Generator.next (<anonymous>)",
-              "    at fulfilled (/Users/lea/Works/corgi/dst/router.js:4:58)",
-              "    at propagateAslWrapper (/Users/lea/Works/corgi/node_modules/async-listener/index.js:502:23)",
-              "    at /Users/lea/Works/corgi/node_modules/async-listener/glue.js:188:31",
-              "    at /Users/lea/Works/corgi/node_modules/async-listener/index.js:539:70",
-              "    at /Users/lea/Works/corgi/node_modules/async-listener/glue.js:188:31",
-              "    at <anonymous>",
-              "    at process._tickCallback (internal/process/next_tick.js:188:7)",
-            ]
-          });
+          const decrypted = rootNamespace.errorFormatter.decryptErrorMetadata(JSON.parse(res["body"]).error.metadata);
+
+          expect(decrypted.message).to.be.eq("TEST ERROR");
+          expect(decrypted.name).to.be.eq("Error");
+
+          expect(decrypted.stack[0]).to.be.eq("Error: TEST ERROR");
+          // Since Stack keep changes depends on CI env, check only the first line
+          // "    at RoutingContext.<anonymous> (/Users/lea/Works/corgi/dst/__test__/root-namespace_spec.js:26:35)",
+          // "    at Generator.next (<anonymous>)",
+          // "    at /Users/lea/Works/corgi/dst/__test__/root-namespace_spec.js:7:71",
+          // "    at new WrappedPromise (/Users/lea/Works/corgi/node_modules/async-listener/es6-wrapped-promise.js:13:18)",
+          // "    at __awaiter (/Users/lea/Works/corgi/dst/__test__/root-namespace_spec.js:3:12)",
+          // "    at RoutingContext.<anonymous> (/Users/lea/Works/corgi/dst/__test__/root-namespace_spec.js:25:32)",
+          // "    at Router.<anonymous> (/Users/lea/Works/corgi/dst/router.js:148:51)",
+          // "    at Generator.next (<anonymous>)",
+          // "    at /Users/lea/Works/corgi/dst/router.js:7:71",
+          // "    at new WrappedPromise (/Users/lea/Works/corgi/node_modules/async-listener/es6-wrapped-promise.js:13:18)",
+          // "    at __awaiter (/Users/lea/Works/corgi/dst/router.js:3:12)",
+          // "    at runRoute (/Users/lea/Works/corgi/dst/router.js:121:65)",
+          // "    at /Users/lea/Works/corgi/dst/router.js:207:60",
+          // "    at Generator.next (<anonymous>)",
+          // "    at fulfilled (/Users/lea/Works/corgi/dst/router.js:4:58)",
+          // "    at propagateAslWrapper (/Users/lea/Works/corgi/node_modules/async-listener/index.js:502:23)",
+          // "    at /Users/lea/Works/corgi/node_modules/async-listener/glue.js:188:31",
+          // "    at /Users/lea/Works/corgi/node_modules/async-listener/index.js:539:70",
+          // "    at /Users/lea/Works/corgi/node_modules/async-listener/glue.js:188:31",
+          // "    at <anonymous>",
+          // "    at process._tickCallback (internal/process/next_tick.js:188:7)",
           expect(res.statusCode).to.be.eq(500);
+
         });
       });
 

--- a/src/__test__/root-namespace_spec.ts
+++ b/src/__test__/root-namespace_spec.ts
@@ -29,7 +29,8 @@ describe("RootNamespace", () => {
 
       context("with CORGI_ERROR_PASSSWORD", () => {
         beforeEach(() => {
-          process.env.CORGI_ERROR_PASSSWORD = "password";
+          // Must be 16 letters.
+          process.env.CORGI_ERROR_PASSSWORD = "9vApxLk5G3PAsJrM";
         });
 
         it("should handler general error and build json response, with encrpyted message", async () => {

--- a/src/__test__/root-namespace_spec.ts
+++ b/src/__test__/root-namespace_spec.ts
@@ -2,7 +2,8 @@ import { expect } from "chai";
 
 import { Route } from '../route';
 import { Router } from '../router';
-import { RootNamespace, StandardError } from '../root-namespace';
+import { StandardError } from "../error_response";
+import { RootNamespace } from '../root-namespace';
 
 class CustomError extends Error {
 
@@ -11,27 +12,79 @@ class CustomError extends Error {
 describe("RootNamespace", () => {
   describe("#exceptionHandler", () => {
     context("with custom error", () => {
-      it("should handler general error and build json response", async () => {
-        const rootNamespace = new RootNamespace([
-          Route.GET('/test', { operationId: "test" }, {}, async function() {
+      let rootNamespace: RootNamespace;
+      const subject = async () => {
+        rootNamespace = new RootNamespace([
+          Route.GET('/test', { operationId: "test" }, {}, async function () {
             throw new CustomError("TEST ERROR");
           })
         ]);
 
         const router = new Router([rootNamespace]);
-        const res = await router.resolve({
+        return await router.resolve({
           path: '/test',
           httpMethod: 'GET',
         } as any, { requestId: "request-id", timeout: 10000 });
+      };
 
-        expect(JSON.parse(res["body"])).to.deep.eq({
-          'error':{
-            'id':'request-id',
-            'code': 'Error',
-            'message':'TEST ERROR'
-          }
+      context("with CORGI_ERROR_PASSSWORD", () => {
+        beforeEach(() => {
+          process.env.CORGI_ERROR_PASSSWORD = "password";
         });
-        expect(res.statusCode).to.be.eq(500);
+
+        it("should handler general error and build json response, with encrpyted message", async () => {
+          const res = await subject();
+          expect(
+            rootNamespace.errorFormatter.decryptErrorMetadata(JSON.parse(res["body"]).error.metadata)
+          ).to.be.deep.eq({
+            "message": "TEST ERROR",
+            "name": "Error",
+            "stack": [
+              "Error: TEST ERROR",
+              "    at RoutingContext.<anonymous> (/Users/lea/Works/corgi/dst/__test__/root-namespace_spec.js:26:35)",
+              "    at Generator.next (<anonymous>)",
+              "    at /Users/lea/Works/corgi/dst/__test__/root-namespace_spec.js:7:71",
+              "    at new WrappedPromise (/Users/lea/Works/corgi/node_modules/async-listener/es6-wrapped-promise.js:13:18)",
+              "    at __awaiter (/Users/lea/Works/corgi/dst/__test__/root-namespace_spec.js:3:12)",
+              "    at RoutingContext.<anonymous> (/Users/lea/Works/corgi/dst/__test__/root-namespace_spec.js:25:32)",
+              "    at Router.<anonymous> (/Users/lea/Works/corgi/dst/router.js:148:51)",
+              "    at Generator.next (<anonymous>)",
+              "    at /Users/lea/Works/corgi/dst/router.js:7:71",
+              "    at new WrappedPromise (/Users/lea/Works/corgi/node_modules/async-listener/es6-wrapped-promise.js:13:18)",
+              "    at __awaiter (/Users/lea/Works/corgi/dst/router.js:3:12)",
+              "    at runRoute (/Users/lea/Works/corgi/dst/router.js:121:65)",
+              "    at /Users/lea/Works/corgi/dst/router.js:207:60",
+              "    at Generator.next (<anonymous>)",
+              "    at fulfilled (/Users/lea/Works/corgi/dst/router.js:4:58)",
+              "    at propagateAslWrapper (/Users/lea/Works/corgi/node_modules/async-listener/index.js:502:23)",
+              "    at /Users/lea/Works/corgi/node_modules/async-listener/glue.js:188:31",
+              "    at /Users/lea/Works/corgi/node_modules/async-listener/index.js:539:70",
+              "    at /Users/lea/Works/corgi/node_modules/async-listener/glue.js:188:31",
+              "    at <anonymous>",
+              "    at process._tickCallback (internal/process/next_tick.js:188:7)",
+            ]
+          });
+          expect(res.statusCode).to.be.eq(500);
+        });
+      });
+
+      context("without CORGI_ERROR_PASSSWORD", () => {
+        beforeEach(() => {
+          delete process.env.CORGI_ERROR_PASSSWORD;
+        });
+
+        it("should handler general error and build json response", async () => {
+          const res = await subject();
+
+          expect(JSON.parse(res["body"])).to.deep.eq({
+            'error': {
+              'id': 'request-id',
+              'code': 'Error',
+              'message': 'TEST ERROR'
+            }
+          });
+          expect(res.statusCode).to.be.eq(500);
+        });
       });
     });
 

--- a/src/error_response.ts
+++ b/src/error_response.ts
@@ -1,3 +1,16 @@
+export class StandardError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    public readonly options: {
+      code: string,
+      message: string,
+      metadata?: object,
+    }
+  ) {
+    super()
+  }
+}
+
 export interface StandardErrorResponseBody {
   error: {
     id?: string;
@@ -13,5 +26,57 @@ export interface StandardErrorResponseBody {
      * Human readable Error message, such as "You're not allowed to do this"
      */
     message: string;
+  }
+}
+
+import * as crypto from "crypto";
+const CipherAlgorithm = "aes-256-ctr";
+
+export class ErrorResponseFormatter {
+  // If Password is provided, it will show detailed information (encrypted)
+  constructor(private password: string | undefined) {
+    console.log("ErrorResponseFormatter : ", password);
+  }
+
+  public format(error: Error) {
+    if (error instanceof StandardError) {
+      return {
+        code: error.options.code,
+        message: error.options.message,
+        metadata: error.options.metadata,
+      };
+    } else {
+      // For Non-Standard error,
+      return {
+        code: error.name,
+        message: error.message,
+        metadata: (() => {
+          console.log("Password : ", this.password);
+          if (this.password) {
+            const cipher = crypto.createCipher(CipherAlgorithm, this.password)
+            return [
+              cipher.update(JSON.stringify({
+                name: error.name,
+                message: error.message,
+                stack: (error.stack || "").split("\n"),
+              }), 'utf8', 'hex'),
+              cipher.final('hex')
+            ].join("");
+          } else {
+            // Otherwise don't show metadata for security
+            return undefined;
+          }
+        })(),
+      };
+    }
+  }
+
+  public decryptErrorMetadata(message: string) {
+    const decipher = crypto.createDecipher(CipherAlgorithm, this.password);
+    const payload = JSON.parse([
+      decipher.update(message, 'hex', 'utf8'),
+      decipher.final('utf8'),
+    ].join(""));
+    return payload;
   }
 }

--- a/src/error_response.ts
+++ b/src/error_response.ts
@@ -34,9 +34,7 @@ const CipherAlgorithm = "aes-256-ctr";
 
 export class ErrorResponseFormatter {
   // If Password is provided, it will show detailed information (encrypted)
-  constructor(private password: string | undefined) {
-    console.log("ErrorResponseFormatter : ", password);
-  }
+  constructor(private password: string | undefined) {}
 
   public format(error: Error) {
     if (error instanceof StandardError) {
@@ -51,7 +49,6 @@ export class ErrorResponseFormatter {
         code: error.name,
         message: error.message,
         metadata: (() => {
-          console.log("Password : ", this.password);
           if (this.password) {
             const cipher = crypto.createCipher(CipherAlgorithm, this.password)
             return [


### PR DESCRIPTION
Currently, when error occurs corgi format error without stackTrace since it can leak internal structure of system.

in order to debug error easily, 
1) if you set **CORGI_ERROR_PASSWORD**
2) error response would have "metadata" which is encrypted stackTrace + error message
3) you can decrypt this with same key
