### PR TITLE
Drop context method usage

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,5 @@
 dst/__test__
 .npm
+.idea
+.code
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vingle-corgi",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vingle-corgi",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vingle-corgi",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "Restful HTTP Framework for AWS Lambda - AWS API Gateway Proxy Integration",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vingle-corgi",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "Restful HTTP Framework for AWS Lambda - AWS API Gateway Proxy Integration",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",

--- a/src/__test__/router_spec.ts
+++ b/src/__test__/router_spec.ts
@@ -162,20 +162,16 @@ describe("Router", () => {
             },
           } as any,
           {
-            succeed: function(result?: Object) {
-              this.done(undefined, result);
-            },
-            fail: function(error: Error) {
-              this.done(error);
-            },
-            done: function(error: Error | null, result?: Response) {
-              resolve(error || result);
-            },
             getRemainingTimeInMillis: function() {
               return 100;
             },
             awsRequestId: "request-id",
-          } as any
+          } as any,
+          (e, res) => {
+            if (e) { return reject(e); }
+
+            resolve(res);
+          },
         );
       });
 

--- a/src/lambda-proxy.ts
+++ b/src/lambda-proxy.ts
@@ -71,9 +71,6 @@ export interface Context {
     callbackWaitsForEmptyEventLoop?: boolean;
 
     // Functions
-    succeed(result?: Object): void;
-    fail(error: Error): void;
-    done(error: Error | null, result?: Response): void; // result must be JSON.stringifyable
     getRemainingTimeInMillis(): number;
 }
 

--- a/src/lambda-proxy.ts
+++ b/src/lambda-proxy.ts
@@ -68,6 +68,7 @@ export interface Context {
     logStreamName: string;
     identity?: CognitoIdentity;
     clientContext?: ClientContext;
+    callbackWaitsForEmptyEventLoop?: boolean;
 
     // Functions
     succeed(result?: Object): void;

--- a/src/router.ts
+++ b/src/router.ts
@@ -89,15 +89,17 @@ export class Router {
   }
 
   handler() {
-    return (event: LambdaProxy.Event, context: LambdaProxy.Context) => {
+    return (event: LambdaProxy.Event, context: LambdaProxy.Context, done: (e: Error | null, res?: LambdaProxy.Response) => void) => {
+      context.callbackWaitsForEmptyEventLoop = false;
+
       const requestId = context.awsRequestId;
       const timeout = context.getRemainingTimeInMillis() * 0.9;
       this.resolve(
         event, { requestId, timeout }
       ).then((response) => {
-        context.succeed(response);
+        done(null, response);
       }, (error) => {
-        context.succeed({
+        done(null, {
           statusCode: 500,
           headers: { 'Content-Type': 'application/json; charset=utf-8' },
           body: JSON.stringify({


### PR DESCRIPTION
Drop context handler method usage from our code, and migrated them as callback.

AWS mentioned that context handler methods were deprecated, and [removed old context method handler usage page from Lambda developer documentation](https://github.com/awsdocs/aws-lambda-developer-guide/commit/3d5f5c06f1caadbfc838750442351cae0b372152#diff-31bc5dab8792cc543955b481142069d8). also there are no versions in currently serviced Node.js runtime versions that does not support handler callback. (There's only one version that does not support handler callback - 0.10. which is dropped version from AWS-side also)