### PR TITLE
v2.1.0 remove redundant query string URL decoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vingle-corgi",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Restful HTTP Framework for AWS Lambda - AWS API Gateway Proxy Integration",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",

--- a/src/__test__/routing-context_spec.ts
+++ b/src/__test__/routing-context_spec.ts
@@ -24,7 +24,7 @@ describe("RoutingContext", () => {
           queryStringParameters: {
             "testId": "12345",
             "not_allowed_param": "xxx",
-            "encodedParam": "%ED%94%BD%EC%8B%9C",
+            "encodedParam": "픽시",
             "arrayParameter[0]": "1",
             "arrayParameter[1]": "2",
             "arrayParameter[2]": "3",
@@ -83,7 +83,7 @@ describe("RoutingContext", () => {
           queryStringParameters: {
             "testId": "12345",
             "not_allowed_param": "xxx",
-            "encodedParam": "%ED%94%BD%EC%8B%9C",
+            "encodedParam": "픽시",
             "arrayParameter[0]": "1",
             "arrayParameter[1]": "2",
             "arrayParameter[2]": "3",
@@ -140,6 +140,7 @@ describe("RoutingContext", () => {
             "testId": "12345",
             "not_allowed_param": "xxx",
             "encodedParam": "100%users",
+            "doubleEncodedParam": "vingle%3A%2F%2Finterests%2F%EB%B9%99%EA%B8%80%EB%9F%AC",
             "arrayParameter[0]": "1",
             "arrayParameter[1]": "2",
             "arrayParameter[2]": "3",
@@ -153,6 +154,7 @@ describe("RoutingContext", () => {
         context.validateAndUpdateParams({
           testId: Parameter.Query(Joi.number()),
           encodedParam: Parameter.Query(Joi.string()),
+          doubleEncodedParam: Parameter.Query(Joi.string()),
           update: Parameter.Body(Joi.object({
             fieldA: Joi.number(),
             fieldC: Joi.object({
@@ -167,6 +169,7 @@ describe("RoutingContext", () => {
         expect(context.params).to.deep.eq({
           testId: 12345,
           encodedParam: "100%users",
+          doubleEncodedParam: "vingle%3A%2F%2Finterests%2F%EB%B9%99%EA%B8%80%EB%9F%AC",
           update: {
             fieldA: 12345,
             fieldC: {

--- a/src/routing-context.ts
+++ b/src/routing-context.ts
@@ -97,7 +97,7 @@ export class RoutingContext {
       // API Gateway only support string parsing.
       // but with this, now it would support Array<String> / Map<String, String> parsing too
       const queryStringParameters = qs.parse(qs.stringify(this.request.queryStringParameters));
-      validate(this.decodeURI(queryStringParameters), groupByIn.query);
+      validate(queryStringParameters, groupByIn.query);
     }
     if (groupByIn.body) {
       validate(this.bodyJSON, groupByIn.body);


### PR DESCRIPTION
#### Is it a breaking change?: YES

### Why did you make these changes?

API Gateway decodes query string parameter automatically.

### What's changed in these changes?

- Removed redundant query string URL decoding

Requested URL | API G/W | Corgi (Old) | Corgi (New)
-- | ----------- | -------------- | -------------
`https://api-gw-id.execute-api.us-east-1.amazonaws.com/prod/pets?name=%ED%94%BD%EC%8B%9C` | `{ name: "아이린" }` | `{ name: "아이린" }` | `{ name: "아이린" }`
`https://api-gw-id.execute-api.us-east-1.amazonaws.com/prod/pets?name=%25EC%2595%2584%25EC%259D%25B4%25EB%25A6%25B0` | `{ name: "%EC%95%84%EC%9D%B4%EB%A6%B0" }` | `{ name: "아이린" }` | `{ name: "%EC%95%84%EC%9D%B4%EB%A6%B0" }`


### What do you especially want to get reviewed?

N/A

### Is there any other comments that every teammate should know?

N/A

### Submission Type

* [x] Bugfix

### All Submissions

* [x] Have you added an explanation of what your changes?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you checked potential side effects that could make bad impacts to other services?
